### PR TITLE
Refactor portfolio layout with Tailwind and lazy animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Portfolio
+
+Simple static portfolio. Sections are split into partial HTML files under `partials/` for use with template engines or static site generators.
+
+## Customization
+
+### Header (`partials/header.html`)
+- Update the name inside the `<h1>` tag.
+- Replace menu icons or destinations in the `<nav>` list.
+
+### Hero (`partials/hero.html`)
+- Replace `./img/img-1_mobile.jpg` and `./img/perfil.jpg` with your own images.
+- Edit the introductory text and button link.
+
+### Projects (`partials/projects.html`)
+- Each project box includes an image, title and description.
+- Swap the project images under `img/` or adjust the paths.
+- Update titles, descriptions and the "More work" button URL.
+
+### Contact (`partials/contact.html`)
+- Change the email address or add links to other profiles.
+
+### Styles (`style.css`)
+- The layout uses [TailwindCSS](https://tailwindcss.com/) via CDN for responsive flex/grid utilities.
+- Override colors, fonts or add custom rules in `style.css` as needed.
+
+### Scripts (`script.js`)
+- ScrollReveal is loaded only on wide screens and animations trigger when elements enter the viewport, reducing work on mobile devices.
+
+## Development
+
+To assemble the final page, use a static site generator or template engine that can include the files in `partials/` (e.g., SSI with `<!--#include virtual="partials/header.html" -->`).

--- a/index.html
+++ b/index.html
@@ -6,78 +6,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Joaquin Villanueva | Portfolio</title>
     <link rel="icon" type="image/png" sizes="32x32" href="./img/Code icon.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script src="https://unpkg.com/scrollreveal"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.10.3/gsap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.10.3/EaselPlugin.min.js"></script>    
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.10.3/EaselPlugin.min.js"></script>
 </head>
-<header>
-    <h1>Joaquin Villanueva<span class="ani_character">_</span>
-    </h1>
-    <div class="menu-hamb">
-        <img class="activator" id="activator" src="//s.svgbox.net/hero-outline.svg?fill=fff#menu-alt-3" alt="">
-        <nav>
-            <ul>
-                <li><a href="#"><img src="//s.svgbox.net/hero-outline.svg?fill=e5e2e4#beaker"></a></li>
-                <li><a href="#"><img src="//s.svgbox.net/hero-outline.svg?fill=e5e2e4#chat"></a></li>
-            </ul>
-        </nav>
-    </div>
-</header>
 <body>
-    <section class="first-section">
-        <img src="./img/img-1_mobile.jpg" alt="">
-        <div class="first-panel">
-            <img class="img-perfil" src="./img/perfil.jpg" alt="">
-            <h2>Hi! <br>
-                I'm Joaquín.</h2>
-            <br>
-            <h3>I've been studying Front-end development for six months. I did it on my own with some help of Udemy and Coderhood.
-                I'm looking for a job currently, if my profile is of your interest contact me via Linkedin.
-                (Find the link at bottom of the page)</h3>
-            <br>
-            <a href="http://" rel="noopener noreferrer">
-                <button class="btn about-me" h>About me</button>
-            </a>
-        </div>
-    </section>
-    <section class="second-section">
-        <div class="container">
-            <h2 class="tools">¡Hecha un vistazo a algunos trabajos que he realizado!
-            </h2>
-            <br>
-            <div>
-                <div class="box rv1">
-                    <img src="./img/icons8-html-100.png" alt="">
-                    <p class="box-title">EntreLanas&Agujas</p>
-                    <p class="box-p">Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate, necessitatibus.</p>
-                </div>
-                <div class="box rv2">
-                    <img src="./img/icons8-html-100.png" alt="">
-                    <p class="box-title">Lorem ipsum amet.</p>
-                    <p class="box-p">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Aliquam, in!</p>
-                </div>
-                <div class="box rv3">
-                    <img src="./img/icons8-html-100.png" alt="">
-                    <p class="box-title">Lorem sit amet.</p>
-                    <p class="box-p">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quam, quas.</p>
-                </div>
-                <a href="http://">
-                    <button class="btn more-work">More work</button>
-                </a>
-            </div>
-        </div>
-    </section>
-    <section class="third-section">
-        <h2>
-            Contact Me
-        </h2>
-        <div>
-            <a class="email-link" href = "mailto: joaquinvillanuevafarber@gmail.com"><i class="material-icons">email</i></a>
-            <a class="email-link" href = "#"><i class="material-icons">article</i></a>
-        </div>
-    </section>
+    <!--#include virtual="partials/header.html" -->
+    <!--#include virtual="partials/hero.html" -->
+    <!--#include virtual="partials/projects.html" -->
+    <!--#include virtual="partials/contact.html" -->
     <script src="script.js"></script>
 </body>
 </html>

--- a/partials/contact.html
+++ b/partials/contact.html
@@ -1,0 +1,7 @@
+<section class="third-section flex flex-col items-center">
+    <h2>Contact Me</h2>
+    <div class="flex">
+        <a class="email-link" href="mailto: joaquinvillanuevafarber@gmail.com"><i class="material-icons">email</i></a>
+        <a class="email-link" href="#"><i class="material-icons">article</i></a>
+    </div>
+</section>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,12 @@
+<header>
+    <h1>Joaquin Villanueva<span class="ani_character">_</span></h1>
+    <div class="menu-hamb">
+        <img class="activator" id="activator" src="//s.svgbox.net/hero-outline.svg?fill=fff#menu-alt-3" alt="">
+        <nav>
+            <ul>
+                <li><a href="#"><img src="//s.svgbox.net/hero-outline.svg?fill=e5e2e4#beaker" alt=""></a></li>
+                <li><a href="#"><img src="//s.svgbox.net/hero-outline.svg?fill=e5e2e4#chat" alt=""></a></li>
+            </ul>
+        </nav>
+    </div>
+</header>

--- a/partials/hero.html
+++ b/partials/hero.html
@@ -1,0 +1,13 @@
+<section class="first-section flex flex-col">
+    <img src="./img/img-1_mobile.jpg" alt="">
+    <div class="first-panel flex flex-col items-center justify-center">
+        <img class="img-perfil" src="./img/perfil.jpg" alt="">
+        <h2>Hi! <br>I'm Joaquín.</h2>
+        <br>
+        <h3>I've been studying Front-end development for six months. I did it on my own with some help of Udemy and Coderhood. I'm looking for a job currently, if my profile is of your interest contact me via Linkedin. (Find the link at bottom of the page)</h3>
+        <br>
+        <a href="http://" rel="noopener noreferrer">
+            <button class="btn about-me">About me</button>
+        </a>
+    </div>
+</section>

--- a/partials/projects.html
+++ b/partials/projects.html
@@ -1,0 +1,26 @@
+<section class="second-section">
+    <div class="projects-container">
+        <h2 class="tools">¡Hecha un vistazo a algunos trabajos que he realizado!</h2>
+        <br>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-center">
+            <div class="box flex flex-col justify-center items-center rv1">
+                <img src="./img/icons8-html-100.png" alt="">
+                <p class="box-title">EntreLanas&Agujas</p>
+                <p class="box-p">Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate, necessitatibus.</p>
+            </div>
+            <div class="box flex flex-col justify-center items-center rv2">
+                <img src="./img/icons8-html-100.png" alt="">
+                <p class="box-title">Lorem ipsum amet.</p>
+                <p class="box-p">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Aliquam, in!</p>
+            </div>
+            <div class="box flex flex-col justify-center items-center rv3">
+                <img src="./img/icons8-html-100.png" alt="">
+                <p class="box-title">Lorem sit amet.</p>
+                <p class="box-p">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quam, quas.</p>
+            </div>
+        </div>
+        <a href="http://">
+            <button class="btn more-work">More work</button>
+        </a>
+    </div>
+</section>

--- a/script.js
+++ b/script.js
@@ -1,48 +1,64 @@
-ScrollReveal().reveal(document.querySelector(".rv1"), {
-  reset: true,
-  duration: 1500,
-});
-ScrollReveal().reveal(document.querySelector(".rv2"), {
-  reset: true,
-  duration: 1800,
-});
-ScrollReveal().reveal(document.querySelector(".rv3"), {
-  reset: true,
-  duration: 1800,
-});
-ScrollReveal().reveal(document.querySelector(".more-work"), {
-  reset: true,
-  duration: 1800,
-});
+if (window.innerWidth > 768) {
+  const srScript = document.createElement('script');
+  srScript.src = 'https://unpkg.com/scrollreveal';
+  srScript.onload = () => {
+    const targets = [
+      { selector: '.rv1', duration: 1500 },
+      { selector: '.rv2', duration: 1800 },
+      { selector: '.rv3', duration: 1800 },
+      { selector: '.more-work', duration: 1800 }
+    ];
 
-var card = document.getElementById("activator");
-var tl = gsap.timeline({ defaults: { ease: "power2.inOut" } });
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const cfg = targets.find(t => entry.target.matches(t.selector));
+          if (cfg) {
+            ScrollReveal().reveal(entry.target, { reset: true, duration: cfg.duration });
+          }
+          obs.unobserve(entry.target);
+        }
+      });
+    });
+
+    targets.forEach(t => {
+      const el = document.querySelector(t.selector);
+      if (el) {
+        observer.observe(el);
+      }
+    });
+  };
+  document.head.appendChild(srScript);
+}
+
+var card = document.getElementById('activator');
+var tl = gsap.timeline({ defaults: { ease: 'power2.inOut' } });
 
 var toggle = false;
 
-tl.to(".activator", {
-  "background-color": "#040507",
-  borderRadius: "5em 5em 0 0",
+tl.to('.activator', {
+  'background-color': '#040507',
+  borderRadius: '5em 5em 0 0',
 });
 tl.to(
-  "nav",
+  'nav',
   {
-    clipPath: "ellipse(100% 100% at 50% 50%)",
+    clipPath: 'ellipse(100% 100% at 50% 50%)',
   },
-  "-=0.5"
+  '-=0.5'
 );
 tl.to(
-  "nav img",
+  'nav img',
   {
     opacity: 1,
-    transform: "translateX(0px)",
-    stagger: .05,
+    transform: 'translateX(0px)',
+    stagger: 0.05,
   },
-  "-=.5"
+  '-=.5'
 );
 tl.pause();
 
-card.addEventListener("click", () => {
+card.addEventListener('click', () => {
   toggle = !toggle;
   if (toggle ? tl.play() : tl.reverse());
 });

--- a/style.css
+++ b/style.css
@@ -1,10 +1,14 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap');*{
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap');
+
+/* Base styles */
+* {
     box-sizing: border-box;
     padding: 0;
     margin: 0;
     font-family: 'Poppins', sans-serif;
 }
-header{
+
+header {
     height: 50px;
     width: 100%;
     background-color: #040507;
@@ -14,13 +18,15 @@ header{
     position: fixed;
     z-index: 99;
 }
-header h1{
+
+header h1 {
     color: #e5e2e4;
     margin-left: 2%;
     text-transform: uppercase;
     font-size: 1.2rem;
 }
-header .ani_character{
+
+header .ani_character {
     animation: likeCode 1s infinite;
 }
 
@@ -30,6 +36,7 @@ header .ani_character{
     position: relative;
     top: 50px;
 }
+
 .menu-hamb .activator {
     padding: 1em;
     border-radius: 5em 5em 0 0;
@@ -46,75 +53,60 @@ header .ani_character{
     margin: 0;
     padding: 0;
 }
+
 .menu-hamb nav {
-    /* color: #0d0f14; */
     background: #040507;
     border-radius: 0 0 5em 5em;
-    padding: 0em;
+    padding: 0;
     clip-path: ellipse(50% 50% at -50% 50%);
+}
 
-}
-.menu-hamb nav ul {
-    /* display: flex-inline; */
-}
 .menu-hamb nav li a {
     display: block;
-    border-radius: 50%;    
+    border-radius: 50%;
 }
+
 .menu-hamb nav img {
     opacity: 0;
     transform: translateX(-10px);
 }
+
 .menu-hamb nav:hover {
-    background: rgb(50,56,68);
+    background: rgb(50, 56, 68);
 }
 
-.img-perfil{
+.img-perfil {
     height: 100px;
     width: 100px;
     border-radius: 100%;
 }
-@keyframes likeCode { 
-    0%{
-        opacity: 0;
-    }
-    50% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 1;
-    }
+
+@keyframes likeCode {
+    0% { opacity: 0; }
+    50% { opacity: 0; }
+    100% { opacity: 1; }
 }
 
-
-body .first-section{
+body .first-section {
     background-color: #fde603;
-    display: flex;
-    flex-direction: column;
     position: relative;
     top: 50px;
 }
-.first-panel{
-    display: flex;
-    position: relative;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+
+.first-panel {
     margin: 0 30px 15px 30px;
 }
-.first-section img{
-    margin-bottom: 20px;
 
+.first-section img {
+    margin-bottom: 20px;
 }
-.first-panel h2, .first-panel h3{
+
+.first-panel h2,
+.first-panel h3 {
     text-align: center;
 }
 
-
-first-section div h3{
-    max-width: 700px;
-}
-.btn{
+.btn {
     background-color: #e5e2e4;
     border: none;
     border-radius: 15px;
@@ -122,69 +114,60 @@ first-section div h3{
     font-weight: 700;
 }
 
-
-.second-section h2, .second-section>div{
-    /* position: relative;
-    top: 50px; */
-}
-.second-section{
+.second-section {
     background-color: #040507;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
 }
-.container{
+
+.projects-container {
     margin: 60px 0 30px 0;
 }
-.second-section h2{
-    color: #fde603;    
+
+.second-section h2 {
+    color: #fde603;
     margin: 0 20px;
     text-align: center;
     position: relative;
 }
-.second-section .container>div{
-    display: flex;    
-    flex-direction: column;
-    color: #e5e2e4;
-    min-height: 275px;
-    align-items: center;
-}
-.second-section .more-work{
+
+.second-section .more-work {
     max-width: 100px;
+    margin-top: 20px;
 }
-.box{
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+
+.box {
     margin-bottom: 20px;
 }
-.box .box-title, .box .box-p{
+
+.box .box-title,
+.box .box-p {
     max-width: 70%;
     text-align: center;
 }
-.box-title{
+
+.box-title {
     font-weight: 700;
     text-align: center;
 }
-.box-p{
+
+.box-p {
     color: #fde603;
     font-weight: 400;
 }
-.box img{
+
+.box img {
     background-color: #fde603;
 }
 
-
-.third-section{
+.third-section {
     background-color: #fde603;
     height: 75px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
 }
-.third-section .email-link{
+
+.third-section .email-link {
     text-decoration: none;
     color: #040507;
 }


### PR DESCRIPTION
## Summary
- Load TailwindCSS via CDN and drop custom utility class definitions
- Lazy-load ScrollReveal on desktop and keep animations off mobile
- Document Tailwind usage and script behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9dfd9c9c8333a9c35f1104bf4ece