### PR TITLE
fix: guard nav toggle when activator missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,33 +32,35 @@ if (window.innerWidth > 768) {
 }
 
 var card = document.getElementById('activator');
-var tl = gsap.timeline({ defaults: { ease: 'power2.inOut' } });
+if (card) {
+  var tl = gsap.timeline({ defaults: { ease: 'power2.inOut' } });
 
-var toggle = false;
+  var toggle = false;
 
-tl.to('.activator', {
-  'background-color': '#040507',
-  borderRadius: '5em 5em 0 0',
-});
-tl.to(
-  'nav',
-  {
-    clipPath: 'ellipse(100% 100% at 50% 50%)',
-  },
-  '-=0.5'
-);
-tl.to(
-  'nav img',
-  {
-    opacity: 1,
-    transform: 'translateX(0px)',
-    stagger: 0.05,
-  },
-  '-=.5'
-);
-tl.pause();
+  tl.to('.activator', {
+    'background-color': '#040507',
+    borderRadius: '5em 5em 0 0',
+  });
+  tl.to(
+    'nav',
+    {
+      clipPath: 'ellipse(100% 100% at 50% 50%)',
+    },
+    '-=0.5'
+  );
+  tl.to(
+    'nav img',
+    {
+      opacity: 1,
+      transform: 'translateX(0px)',
+      stagger: 0.05,
+    },
+    '-=.5'
+  );
+  tl.pause();
 
-card.addEventListener('click', () => {
-  toggle = !toggle;
-  if (toggle ? tl.play() : tl.reverse());
-});
+  card.addEventListener('click', () => {
+    toggle = !toggle;
+    if (toggle ? tl.play() : tl.reverse());
+  });
+}


### PR DESCRIPTION
## Summary
- avoid runtime error by checking for activator element before binding nav toggle

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9cc42b288333a3285263288e915c